### PR TITLE
Instructions for installing jruby-pg via Gemfile

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -41,7 +41,7 @@ Install via RubyGems:
 
 Install via Bundler, in your gemfile add the following:
 
-    # Pleae note that the 1.0 is necessary to let bundler do its dependency management, as there is no .gemspec in the source.
+    # Please note that the 1.0 is necessary to let bundler do its dependency management, as there is no .gemspec in the source.
     gem 'jruby-pg', '1.0', :platform => :jruby, :git => 'git://github.com/headius/jruby-pg.git', :branch => :master
 
 == Copying

--- a/README.rdoc
+++ b/README.rdoc
@@ -39,6 +39,11 @@ Install via RubyGems:
 
     gem install jruby-pg
 
+Install via Bundler, in your gemfile add the following:
+
+    # Pleae note that the 1.0 is necessary to let bundler do its dependency management, as there is no .gemspec in the source.
+    gem 'jruby-pg', '1.0', :platform => :jruby, :git => 'git://github.com/headius/jruby-pg.git', :branch => :master
+
 == Copying
 
 Copyright (c) 1997-2013 by the authors.


### PR DESCRIPTION
The standard gem 'jruby-pg' does not work. I added a couple of lines to the readme to explain how to get it to work.