### PR TITLE
Make options params optional

### DIFF
--- a/ext/java/org/jruby/pg/messages/Startup.java
+++ b/ext/java/org/jruby/pg/messages/Startup.java
@@ -19,8 +19,12 @@ public class Startup extends FrontendMessage {
     writer.writeString(user);
     writer.writeString("database");
     writer.writeString(database);
-    writer.writeString("options");
-    writer.writeString(options);
+
+    if(!options.isEmpty()) {
+      writer.writeString("options");
+      writer.writeString(options);
+    }
+
     writer.writeByte((char) 0);
   }
 


### PR DESCRIPTION
Fix compatibility with pgbouncer

Without fix:
```
PG::ConnectionBad: ERROR: Unsupported startup parameter: options
org/jruby/pg/Connection.java:365:in `initialize'
/srv/cattani/vendor/bundle/jruby/1.9/gems/activerecord-4.1.10/lib/active_record/connection_adapters/postgresql_adapter.rb:888:in `connect'
/srv/cattani/vendor/bundle/jruby/1.9/gems/activerecord-4.1.10/lib/active_record/connection_adapters/postgresql_adapter.rb:568:in `initialize'
/srv/cattani/vendor/bundle/jruby/1.9/gems/activerecord-4.1.10/lib/active_record/connection_adapters/postgresql_adapter.rb:41:in `postgresql_connection'
```

Similar issue: https://github.com/brianc/node-postgres/issues/270

Related to the fix: is it possible that `options` will have `null` value?